### PR TITLE
Feat: Add profilepage + overview tab

### DIFF
--- a/src/components/CompanyCard.tsx
+++ b/src/components/CompanyCard.tsx
@@ -16,9 +16,10 @@ interface CompanyCardProps {
   isBookmarked: boolean;
   onToggleBookmark: (siren: string) => void;
   onExport?: (company: any) => void;
+  onCardClick: (company: any) => void; // New prop for navigation
 }
 
-export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport }: CompanyCardProps) {
+export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport, onCardClick }: CompanyCardProps) {
   // Calculate company age and get appropriate color
   const getFoundationBadgeStyle = (dateCreation?: string) => {
     if (!dateCreation) return null;
@@ -89,8 +90,22 @@ export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport 
 
   const foundationStyle = getFoundationBadgeStyle(company.date_creation);
 
+  // Handle card click but prevent action buttons from triggering it
+  const handleCardClick = (e: React.MouseEvent) => {
+    // Check if the click target is a button or inside a button
+    const target = e.target as HTMLElement;
+    const isButton = target.closest('button');
+    
+    if (!isButton) {
+      onCardClick(company);
+    }
+  };
+
   return (
-    <Card className="group relative overflow-hidden bg-white/80 backdrop-blur-sm border-0 shadow-lg hover:shadow-2xl transition-all duration-500 hover:-translate-y-2 rounded-2xl">
+    <Card 
+      className="group relative overflow-hidden bg-white/80 backdrop-blur-sm border-0 shadow-lg hover:shadow-2xl transition-all duration-500 hover:-translate-y-2 rounded-2xl cursor-pointer"
+      onClick={handleCardClick}
+    >
       {/* Gradient overlay */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-transparent to-purple-50/50 opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
       
@@ -161,7 +176,10 @@ export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport 
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => onToggleBookmark(company.siren)}
+            onClick={(e) => {
+              e.stopPropagation(); // Prevent card click
+              onToggleBookmark(company.siren);
+            }}
             className={`h-10 w-10 rounded-full transition-all duration-300 ${
               isBookmarked 
                 ? 'bg-blue-100 text-blue-600 hover:bg-blue-200' 
@@ -174,6 +192,10 @@ export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport 
           <Button
             variant="ghost"
             size="icon"
+            onClick={(e) => {
+              e.stopPropagation(); // Prevent card click
+              // Handle external link action here
+            }}
             className="h-10 w-10 rounded-full hover:bg-gray-100 transition-all duration-300"
           >
             <ExternalLink className="h-5 w-5" />
@@ -183,7 +205,10 @@ export function CompanyCard({ company, isBookmarked, onToggleBookmark, onExport 
         <Button 
           variant="outline" 
           size="sm"
-          onClick={() => onExport?.(company)}
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent card click
+            onExport?.(company);
+          }}
           className="bg-white/80 backdrop-blur-sm border-gray-200 hover:bg-blue-50 hover:border-blue-300 hover:text-blue-600 transition-all duration-300 rounded-full px-4 py-2"
         >
           <DownloadCloud className="mr-2 h-4 w-4" />

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,0 +1,111 @@
+import { Fragment, useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import type { ExportField } from "../constants/ExportFields";
+
+export type ExportModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  company: Record<string, any>;
+  /** tous les champs disponibles pour l’export */
+  fields: ExportField[];
+  /**
+   * callback quand on confirme l’export :
+   * @param selectedKeys liste des clés cochées
+   * @param format "csv" ou "json"
+   */
+  onConfirm: (selectedKeys: string[], format: "csv" | "json") => void;
+};
+
+export function ExportModal({
+  isOpen,
+  onClose,
+  company,
+  fields,
+  onConfirm,
+}: ExportModalProps) {
+  const [selected, setSelected] = useState<Set<string>>(
+    new Set(fields.map((f) => f.key))
+  );
+
+  const toggle = (key: string) => {
+    const next = new Set(selected);
+    next.has(key) ? next.delete(key) : next.add(key);
+    setSelected(next);
+  };
+
+  const handleDownload = (format: "csv" | "json") => {
+    onConfirm(Array.from(selected), format);
+    onClose();
+  };
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog onClose={onClose} className="fixed inset-0 z-10 overflow-y-auto">
+        <div className="flex items-center justify-center min-h-screen px-4">
+          <Transition.Child
+            as={Fragment}
+            enter="transition-opacity ease-linear duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity ease-linear duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-30" />
+          </Transition.Child>
+
+          <Transition.Child
+            as={Fragment}
+            enter="transition ease-out duration-200 transform"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="transition ease-in duration-150 transform"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+              <Dialog.Title className="text-lg font-medium">
+                Exporter les champs
+              </Dialog.Title>
+
+              <div className="mt-4 space-y-2 max-h-60 overflow-y-auto">
+                {fields.map((f) => (
+                  <label key={f.key} className="flex items-center">
+                    <input
+                      type="checkbox"
+                      className="mr-2"
+                      checked={selected.has(f.key)}
+                      onChange={() => toggle(f.key)}
+                    />
+                    <span>{f.label}</span>
+                  </label>
+                ))}
+              </div>
+
+              <div className="mt-6 flex justify-end space-x-2">
+                <button
+                  onClick={onClose}
+                  className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+                >
+                  Annuler
+                </button>
+                <button
+                  onClick={() => handleDownload("csv")}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                  Télécharger CSV
+                </button>
+                <button
+                  onClick={() => handleDownload("json")}
+                  className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                >
+                  Télécharger JSON
+                </button>
+              </div>
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/src/components/ResultsList.tsx
+++ b/src/components/ResultsList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useSearch } from "../hooks/useSearch";
 import { useSuggestions } from "../hooks/useSuggestions";
 import { usePagination } from "../hooks/usePagination";
@@ -9,11 +10,16 @@ import { EmptyState } from "./EmptyState";
 import { NoResultsState } from "./NoResultsState";
 import { ErrorState } from "./ErrorState";
 import { ResultsHeader } from "./ResultsHeader";
+import CompanyProfilePage from "./profile/CompanyProfilePage";
 
 export function ResultsList() {
   const { query } = useSearch();
   const { data, loading, error } = useSuggestions(query);
   const { toggleBookmark, isBookmarked } = useBookmarks();
+  
+  // Navigation state
+  const [selectedCompany, setSelectedCompany] = useState<any>(null);
+  const [currentView, setCurrentView] = useState<'list' | 'profile'>('list');
   
   const companies = data?.resultats_nom_entreprise || [];
   const {
@@ -31,7 +37,29 @@ export function ResultsList() {
     // TODO later
   };
 
-  // Render different states
+  // Handle card click - navigate to profile
+  const handleCardClick = (company: any) => {
+    setSelectedCompany(company);
+    setCurrentView('profile');
+  };
+
+  // Handle back to list
+  const handleBackToList = () => {
+    setCurrentView('list');
+    setSelectedCompany(null);
+  };
+
+  // Render profile page if company is selected
+  if (currentView === 'profile' && selectedCompany) {
+    return (
+      <CompanyProfilePage 
+        company={selectedCompany} 
+        onBack={handleBackToList} 
+      />
+    );
+  }
+
+  // Render different states for list view
   if (loading) return <LoadingState />;
   if (error) return <ErrorState error={error} />;
   if (!query.trim()) return <EmptyState />;
@@ -55,6 +83,7 @@ export function ResultsList() {
             isBookmarked={isBookmarked(company.siren)}
             onToggleBookmark={toggleBookmark}
             onExport={handleExport}
+            onCardClick={handleCardClick} // Add navigation handler
           />
         ))}
       </div>

--- a/src/components/profile/CompanyProfilePage.tsx
+++ b/src/components/profile/CompanyProfilePage.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import type { Company } from "../../types/company";
+import { ProfileHeader } from "./ProfileHeader";
+import { ProfileTabs } from "./ProfileTabs";
+import { OverviewTab } from "./tabs/OverviewTab";
+
+interface CompanyProfilePageProps {
+  company: Company;
+  onBack: () => void;
+}
+
+export default function CompanyProfilePage({ company, onBack }: CompanyProfilePageProps) {
+  const [activeTab, setActiveTab] = useState("overview");
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case "overview":
+        return <OverviewTab company={company} />;
+      case "finances":
+        return <div>Finance (TODO later)</div>;
+      case "dirigeants":
+        return <div>Dirigeants (TODO later)</div>;
+      case "documents":
+        return <div>Documents (TODO later)</div>;
+      default:
+        return <OverviewTab company={company} />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50">
+      <ProfileHeader company={company} onBack={onBack} />
+      
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
+        
+        <div className="space-y-6">
+          {renderTabContent()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,42 @@
+import { ArrowLeft, Calendar } from "lucide-react";
+import { Button } from "../ui/button";
+import type { Company } from "../../types/company";
+import { getFoundationBadgeStyle } from "../../utils/foundation-badge";
+
+interface ProfileHeaderProps {
+  company: Company;
+  onBack: () => void;
+}
+
+export function ProfileHeader({ company, onBack }: ProfileHeaderProps) {
+  const foundationStyle = getFoundationBadgeStyle(company.date_creation);
+
+  return (
+    <div className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-10">
+      <div className="max-w-7xl mx-auto px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Button 
+              variant="ghost" 
+              size="icon"
+              onClick={onBack}
+              className="rounded-full hover:bg-gray-100"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">{company.nom_entreprise}</h1>
+              <p className="text-sm text-gray-500">SIREN: {company.siren}</p>
+            </div>
+          </div>
+          {foundationStyle && (
+            <div className={`${foundationStyle.bg} ${foundationStyle.text} px-4 py-2 rounded-full text-sm font-medium flex items-center gap-2`}>
+              <Calendar className="h-4 w-4" />
+              <span>{foundationStyle.year} • {foundationStyle.label}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileTabs.tsx
+++ b/src/components/profile/ProfileTabs.tsx
@@ -1,0 +1,42 @@
+import { Building2, TrendingUp, Users, FileText } from "lucide-react";
+
+export interface Tab {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+const tabs: Tab[] = [
+  { id: "overview", label: "Overview", icon: Building2 },
+  { id: "finances", label: "Finances", icon: TrendingUp },
+  { id: "dirigeants", label: "Dirigeants", icon: Users },
+  { id: "documents", label: "Documents", icon: FileText },
+];
+
+interface ProfileTabsProps {
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+}
+
+export function ProfileTabs({ activeTab, onTabChange }: ProfileTabsProps) {
+  return (
+    <div className="flex gap-1 mb-8 bg-white/60 backdrop-blur-sm p-1 rounded-2xl border border-gray-200">
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onTabChange(tab.id)}
+            className={`flex items-center gap-2 px-6 py-3 rounded-xl font-medium transition-all duration-300 flex-1 justify-center ${
+              activeTab === tab.id
+                ? 'bg-white text-blue-600 shadow-lg'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-white/50'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/profile/tabs/OverviewTab.tsx
+++ b/src/components/profile/tabs/OverviewTab.tsx
@@ -1,0 +1,183 @@
+import { Building2, MapPin } from "lucide-react";
+import { Card, CardHeader, CardContent } from "../../ui/card";
+import { CopyableField } from "../../ui/CopyableField";
+import type { Company } from "../../../types/company";
+import { formatDate } from "../../../utils/formatters";
+
+interface OverviewTabProps {
+  company: Company;
+}
+
+export function OverviewTab({ company }: OverviewTabProps) {
+  // Format complete address
+  const formatCompleteAddress = () => {
+    const parts = [];
+    
+    // Street address
+    if (company.siege.numero_voie && company.siege.type_voie && company.siege.libelle_voie) {
+      const streetAddress = `${company.siege.numero_voie} ${company.siege.type_voie} ${company.siege.libelle_voie}`;
+      parts.push(streetAddress);
+    } else if (company.siege.adresse_ligne_1) {
+      parts.push(company.siege.adresse_ligne_1);
+    }
+    
+    // Second address line
+    if (company.siege.adresse_ligne_2) {
+      parts.push(company.siege.adresse_ligne_2);
+    }
+    
+    // Complement
+    if (company.siege.complement_adresse) {
+      parts.push(company.siege.complement_adresse);
+    }
+    
+    // City with postal code
+    if (company.siege.code_postal && company.siege.ville) {
+      parts.push(`${company.siege.code_postal} ${company.siege.ville}`);
+    } else if (company.siege.ville) {
+      parts.push(company.siege.ville);
+    }
+    
+    // Country
+    if (company.siege.pays) {
+      parts.push(company.siege.pays);
+    }
+    
+    return parts.filter(Boolean).join(', ');
+  };
+
+  const completeAddress = formatCompleteAddress();
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg rounded-2xl">
+        <CardHeader>
+          <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <Building2 className="h-5 w-5" />
+            Informations générales
+          </h3>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <CopyableField
+            label="Nom de l'entreprise"
+            value={company.nom_entreprise}
+          />
+          
+          <CopyableField
+            label="SIREN"
+            value={company.siren}
+            valueClassName="font-mono"
+          />
+          
+          {company.siret && (
+            <CopyableField
+              label="SIRET"
+              value={company.siret_formate || company.siret}
+              valueClassName="font-mono"
+            />
+          )}
+          
+          {company.forme_juridique && (
+            <CopyableField
+              label="Forme juridique"
+              value={company.forme_juridique}
+            />
+          )}
+          
+          {company.date_creation && (
+            <CopyableField
+              label="Date de création"
+              value={formatDate(company.date_creation)}
+            />
+          )}
+
+          {company.code_naf && (
+            <CopyableField
+              label="Code NAF"
+              value={company.code_naf}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg rounded-2xl">
+        <CardHeader>
+          <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <MapPin className="h-5 w-5" />
+            Adresse
+          </h3>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {completeAddress && (
+            <CopyableField
+              label="Adresse complète"
+              value={completeAddress}
+            />
+          )}
+
+          <div className="grid grid-cols-1 gap-4">
+            {company.adresse_ligne_1 && (
+              <CopyableField
+                label="Adresse ligne 1"
+                value={company.adresse_ligne_1}
+              />
+            )}
+            
+            {company.adresse_ligne_2 && (
+              <CopyableField
+                label="Adresse ligne 2"
+                value={company.adresse_ligne_2}
+              />
+            )}
+            
+            {company.complement_adresse && (
+              <CopyableField
+                label="Complément d'adresse"
+                value={company.complement_adresse}
+              />
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              {company.code_postal && (
+                <CopyableField
+                  label="Code postal"
+                  value={company.code_postal}
+                />
+              )}
+              
+              {company.ville && (
+                <CopyableField
+                  label="Ville"
+                  value={company.ville}
+                />
+              )}
+            </div>
+
+            {company.code_commune && (
+              <CopyableField
+                label="Code commune"
+                value={company.code_commune}
+              />
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              {company.pays && (
+                <CopyableField
+                  label="Pays"
+                  value={company.pays}
+                />
+              )}
+              
+              {company.code_pays && (
+                <CopyableField
+                  label="Code pays"
+                  value={company.code_pays}
+                />
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/profile/tabs/OverviewTab.tsx
+++ b/src/components/profile/tabs/OverviewTab.tsx
@@ -9,38 +9,39 @@ interface OverviewTabProps {
 }
 
 export function OverviewTab({ company }: OverviewTabProps) {
+  const siege = company.siege;
   // Format complete address
   const formatCompleteAddress = () => {
     const parts = [];
     
     // Street address
-    if (company.siege.numero_voie && company.siege.type_voie && company.siege.libelle_voie) {
-      const streetAddress = `${company.siege.numero_voie} ${company.siege.type_voie} ${company.siege.libelle_voie}`;
+    if (siege?.numero_voie && siege?.type_voie && siege?.libelle_voie) {
+      const streetAddress = `${siege?.numero_voie} ${siege?.type_voie} ${siege?.libelle_voie}`;
       parts.push(streetAddress);
-    } else if (company.siege.adresse_ligne_1) {
-      parts.push(company.siege.adresse_ligne_1);
+    } else if (siege?.adresse_ligne_1) {
+      parts.push(siege?.adresse_ligne_1);
     }
     
     // Second address line
-    if (company.siege.adresse_ligne_2) {
-      parts.push(company.siege.adresse_ligne_2);
+    if (siege?.adresse_ligne_2) {
+      parts.push(siege?.adresse_ligne_2);
     }
     
     // Complement
-    if (company.siege.complement_adresse) {
-      parts.push(company.siege.complement_adresse);
+    if (siege?.complement_adresse) {
+      parts.push(siege?.complement_adresse);
     }
     
     // City with postal code
-    if (company.siege.code_postal && company.siege.ville) {
-      parts.push(`${company.siege.code_postal} ${company.siege.ville}`);
-    } else if (company.siege.ville) {
-      parts.push(company.siege.ville);
+    if (siege?.code_postal && siege?.ville) {
+      parts.push(`${siege?.code_postal} ${siege?.ville}`);
+    } else if (siege?.ville) {
+      parts.push(siege?.ville);
     }
     
     // Country
-    if (company.siege.pays) {
-      parts.push(company.siege.pays);
+    if (siege?.pays) {
+      parts.push(siege?.pays);
     }
     
     return parts.filter(Boolean).join(', ');
@@ -116,62 +117,62 @@ export function OverviewTab({ company }: OverviewTabProps) {
           )}
 
           <div className="grid grid-cols-1 gap-4">
-            {company.adresse_ligne_1 && (
+            {siege?.adresse_ligne_1 && (
               <CopyableField
                 label="Adresse ligne 1"
-                value={company.adresse_ligne_1}
+                value={siege?.adresse_ligne_1}
               />
             )}
             
-            {company.adresse_ligne_2 && (
+            {siege?.adresse_ligne_2 && (
               <CopyableField
                 label="Adresse ligne 2"
-                value={company.adresse_ligne_2}
+                value={siege?.adresse_ligne_2}
               />
             )}
             
-            {company.complement_adresse && (
+            {siege?.complement_adresse && (
               <CopyableField
                 label="Complément d'adresse"
-                value={company.complement_adresse}
+                value={siege?.complement_adresse}
               />
             )}
 
             <div className="grid grid-cols-2 gap-4">
-              {company.code_postal && (
+              {siege?.code_postal && (
                 <CopyableField
                   label="Code postal"
-                  value={company.code_postal}
+                  value={siege?.code_postal}
                 />
               )}
               
-              {company.ville && (
+              {siege?.ville && (
                 <CopyableField
                   label="Ville"
-                  value={company.ville}
+                  value={siege?.ville}
                 />
               )}
             </div>
 
-            {company.code_commune && (
+            {siege?.code_commune && (
               <CopyableField
                 label="Code commune"
-                value={company.code_commune}
+                value={siege?.code_commune}
               />
             )}
 
             <div className="grid grid-cols-2 gap-4">
-              {company.pays && (
+              {siege?.pays && (
                 <CopyableField
                   label="Pays"
-                  value={company.pays}
+                  value={siege?.pays}
                 />
               )}
               
-              {company.code_pays && (
+              {siege?.code_pays && (
                 <CopyableField
                   label="Code pays"
-                  value={company.code_pays}
+                  value={siege?.code_pays}
                 />
               )}
             </div>

--- a/src/components/ui/CopyableField.tsx
+++ b/src/components/ui/CopyableField.tsx
@@ -1,0 +1,46 @@
+// components/ui/CopyableField.tsx
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { Button } from "./button";
+
+interface CopyableFieldProps {
+  label: string;
+  value: string;
+  className?: string;
+  valueClassName?: string;
+}
+
+export function CopyableField({ label, value, className = "", valueClassName = "" }: CopyableFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div className={`group ${className}`}>
+      <label className="text-sm font-medium text-gray-500 block mb-1">{label}</label>
+      <div className="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2 group-hover:bg-gray-100 transition-colors">
+        <p className={`text-gray-900 font-medium flex-1 ${valueClassName}`}>{value}</p>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleCopy}
+          className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity ml-2"
+        >
+          {copied ? (
+            <Check className="h-4 w-4 text-green-600" />
+          ) : (
+            <Copy className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/ExportFields.ts
+++ b/src/constants/ExportFields.ts
@@ -1,0 +1,43 @@
+export interface ExportField {
+  key: string;
+  label: string;
+}
+
+export const EXPORT_FIELDS: ExportField[] = [
+  { key: "mention",                  label: "Mention" },
+  { key: "siren",                    label: "SIREN" },
+  { key: "siren_formate",            label: "SIREN formaté" },
+  { key: "diffusable",               label: "Diffusable" },
+  { key: "nom_entreprise",           label: "Nom d’entreprise" },
+  { key: "personne_morale",          label: "Personne morale" },
+  { key: "denomination",             label: "Dénomination" },
+  { key: "nom",                      label: "Nom" },
+  { key: "prenom",                   label: "Prénom" },
+  { key: "sexe",                     label: "Sexe" },
+  { key: "entreprise_cessee",        label: "Entreprise cessée" },
+  { key: "statut_rcs",               label: "Statut RCS" },
+  { key: "statut_consolide",         label: "Statut consolidé" },
+  { key: "categorie_juridique",      label: "Catégorie juridique" },
+  { key: "forme_juridique",          label: "Forme juridique" },
+  { key: "date_creation_formate",    label: "Date création" },
+  { key: "code_naf",                 label: "Code NAF" },
+  { key: "libelle_code_naf",         label: "Libellé NAF" },
+  { key: "domaine_activite",         label: "Domaine d’activité" },
+  { key: "siege",                    label: "Siège (JSON)" },
+  { key: "villes",                   label: "Villes (JSON)" },
+  { key: "conventions_collectives",  label: "Conventions collectives (JSON)" },
+  { key: "date_cessation",           label: "Date cessation" },
+  { key: "entreprise_employeuse",    label: "Entreprise employeuse" },
+  { key: "tranche_effectif",         label: "Tranche effectif" },
+  { key: "effectif",                 label: "Effectif" },
+  { key: "effectif_min",             label: "Effectif min." },
+  { key: "effectif_max",             label: "Effectif max." },
+  { key: "economie_sociale_et_solidaire", label: "ESS" },
+  { key: "annee_effectif",           label: "Année effectif" },
+  { key: "association",              label: "Association" },
+  { key: "capital",                  label: "Capital" },
+  { key: "chiffre_affaires",         label: "Chiffre d’affaires" },
+  { key: "resultat",                 label: "Résultat" },
+  { key: "effectifs_finances",       label: "Effectifs finances" },
+  { key: "annee_finances",           label: "Année finances" },
+];

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,0 +1,70 @@
+// types/company.ts
+export interface CompanySiege {
+  siret: string;
+  siret_formate: string;
+  nic: string;
+  numero_voie?: number;
+  indice_repetition?: string;
+  type_voie?: string;
+  libelle_voie?: string;
+  complement_adresse?: string;
+  adresse_ligne_1?: string;
+  adresse_ligne_2?: string;
+  code_postal?: string;
+  code_commune?: string;
+  ville?: string;
+  pays?: string;
+  code_pays?: string;
+}
+
+export interface Company {
+  numero_voie: string;
+  type_voie: string;
+  libelle_voie: string;
+  adresse_ligne_1: string;
+  adresse_ligne_2: string;
+  complement_adresse: string;
+  code_postal: string | undefined;
+  pays: string;
+  siret: string;
+  siret_formate: string;
+  code_commune: string;
+  code_pays: string;
+  siren: string;
+  nom_entreprise: string;
+  forme_juridique?: string;
+  date_creation?: string;
+  chiffre_affaires?: number;
+  resultat?: number;
+  
+  // Siege object containing address details
+  siege?: CompanySiege;
+  
+  // Legacy fields (for backward compatibility with CompanyCard)
+  adresse_complete?: string;
+  siren_formate?: string;
+  code_naf?: string;
+  effectif?: string;
+  domaine_activite?: string;
+  ville?: string; // For CompanyCard compatibility
+  
+  effectifs_finances?: Array<{year: number, effectif: number, ca: number}>;
+  dirigeants?: Array<{
+    nom: string;
+    prenom: string;
+    fonction: string;
+    date_naissance?: string;
+  }>;
+  documents?: Array<{
+    type: string;
+    nom: string;
+    date: string;
+    url?: string;
+  }>;
+  publications?: Array<{
+    type: string;
+    titre: string;
+    date: string;
+    url?: string;
+  }>;
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,14 @@
+export const formatCurrency = (amount?: number): string => {
+  if (!amount) return "N/A";
+  return new Intl.NumberFormat('fr-FR', { 
+    style: 'currency', 
+    currency: 'EUR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0 
+  }).format(amount);
+};
+
+export const formatDate = (dateString?: string): string => {
+  if (!dateString) return "N/A";
+  return new Date(dateString).toLocaleDateString('fr-FR');
+};

--- a/src/utils/foundation-badge.ts
+++ b/src/utils/foundation-badge.ts
@@ -1,0 +1,30 @@
+export interface FoundationBadgeStyle {
+  bg: string;
+  text: string;
+  label: string;
+  year: number;
+}
+
+export const getFoundationBadgeStyle = (dateCreation?: string): FoundationBadgeStyle | null => {
+  if (!dateCreation) return null;
+  
+  const currentYear = new Date().getFullYear();
+  const foundationYear = parseInt(dateCreation.split('-')[0]);
+  const age = currentYear - foundationYear;
+  
+  if (age >= 100) {
+    return { bg: 'bg-slate-900', text: 'text-white', label: 'Centenaire', year: foundationYear };
+  } else if (age >= 75) {
+    return { bg: 'bg-slate-700', text: 'text-white', label: 'Établie', year: foundationYear };
+  } else if (age >= 50) {
+    return { bg: 'bg-slate-600', text: 'text-white', label: 'Expérimentée', year: foundationYear };
+  } else if (age >= 25) {
+    return { bg: 'bg-blue-700', text: 'text-white', label: 'Mature', year: foundationYear };
+  } else if (age >= 10) {
+    return { bg: 'bg-blue-500', text: 'text-white', label: 'Établie', year: foundationYear };
+  } else if (age >= 5) {
+    return { bg: 'bg-blue-400', text: 'text-white', label: 'En croissance', year: foundationYear };
+  } else {
+    return { bg: 'bg-green-400', text: 'text-white', label: 'Jeune', year: foundationYear };
+  }
+};


### PR DESCRIPTION
<!-- Merci de votre contribution ! -->

## 📝 Ce que j’ai fait
- En cliquant sur le nom de l'entreprise, vous êtes redirigé vers profilepage qui contient 4 tabs. Pour l'instant j'ai implementé overview page

## 🔨 Type de changement
- [x] `feat:` nouvelle fonctionnalité
- [ ] `fix:` correction de bug
- [ ] `docs:` documentation uniquement
- [ ] `style:` mise en forme (indentation, espaces)
- [ ] `refactor:` refactoring du code sans ajout de fonctionnalité
- [ ] `test:` ajout ou correction de tests
- [ ] `chore:` maintenance du build ou des outils

## ✅ Checklist
- [x] Les onglets sont visibles et cliquables, l’onglet actif est mis en évidence  
- [x] Chaque onglet affiche les données correctes issues de l’API `/companies/{siren}`  

## 📸 Captures
<img width="938" height="892" alt="image" src="https://github.com/user-attachments/assets/0e4bbe67-65de-443c-af71-73f43c0f1281" />